### PR TITLE
Promote staging CI/CD and always-on CI gate to main

### DIFF
--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
         cache: pip

--- a/.github/actions/setup-frontend/action.yml
+++ b/.github/actions/setup-frontend/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: npm

--- a/.github/docker-images.json
+++ b/.github/docker-images.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "backend-api",
+    "file": "docker/backend.Dockerfile",
+    "target": "main"
+  },
+  {
+    "name": "backend-scheduler",
+    "file": "docker/backend.Dockerfile",
+    "target": "scheduler-image"
+  },
+  {
+    "name": "frontend-web",
+    "file": "docker/frontend_web.Dockerfile",
+    "target": ""
+  },
+  {
+    "name": "frontend-pwa",
+    "file": "docker/frontend_pwa.Dockerfile",
+    "target": ""
+  }
+]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,6 @@ concurrency:
 
 permissions:
   contents: read
-  security-events: write
 
 env:
   IMAGE_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
@@ -64,7 +63,7 @@ jobs:
           echo "deploy_dir=$DEPLOY_DIR" >> "$GITHUB_OUTPUT"
           echo "Deploy stage=$STAGE dir=~/$DEPLOY_DIR sha=$IMAGE_SHA"
 
-  build-scan-push:
+  build-push:
     runs-on: ubuntu-latest
     needs: gate
     strategy:
@@ -139,46 +138,6 @@ jobs:
           provenance: false
           sbom: false
 
-      # One image scan; SARIF, table gate, and SBOM are derived via `trivy convert`.
-      # ignore-unfixed: true — CVEs without an available patch are excluded from the gate.
-      # We accept that trade-off so deploys are not blocked by issues we cannot remediate yet.
-      - name: Scan image with Trivy
-        uses: aquasecurity/trivy-action@v0.36.0
-        with:
-          version: v0.71.2
-          scan-type: image
-          image-ref: ${{ matrix.image }}:${{ env.IMAGE_SHA }}
-          format: json
-          output: trivy-results.json
-          ignore-unfixed: true
-          scanners: vuln
-          list-all-pkgs: true
-          exit-code: 0
-
-      - name: Generate reports and gate on findings
-        run: |
-          trivy convert --format sarif --severity CRITICAL,HIGH \
-            --output trivy-results.sarif trivy-results.json
-          trivy convert --format spdx-json \
-            --output "sbom-${{ matrix.name }}.spdx.json" trivy-results.json
-          trivy convert --format table --severity CRITICAL,HIGH --scanners vuln \
-            --exit-code 1 trivy-results.json
-
-      - name: Upload Trivy SARIF
-        uses: github/codeql-action/upload-sarif@v4
-        if: ${{ !cancelled() && hashFiles('trivy-results.sarif') != '' }}
-        with:
-          sarif_file: trivy-results.sarif
-          category: trivy-${{ needs.gate.outputs.stage }}-${{ matrix.name }}
-
-      - name: Upload SBOM
-        uses: actions/upload-artifact@v7
-        if: ${{ !cancelled() }}
-        with:
-          name: sbom-${{ needs.gate.outputs.stage }}-${{ matrix.name }}
-          path: sbom-${{ matrix.name }}.spdx.json
-          retention-days: 90
-
       - name: Push image
         run: |
           docker push "${{ matrix.image }}:${{ env.IMAGE_SHA }}"
@@ -190,7 +149,7 @@ jobs:
 
   deploy:
     runs-on: self-hosted
-    needs: [gate, build-scan-push]
+    needs: [gate, build-push]
     env:
       DEPLOY_DIR: ${{ needs.gate.outputs.deploy_dir }}
       STAGE: ${{ needs.gate.outputs.stage }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,7 @@
 name: CD
 
+run-name: CD ${{ inputs.stage || github.event.workflow_run.head_branch || github.ref_name }}
+
 on:
   workflow_run:
     workflows: [CI]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       stage: ${{ steps.meta.outputs.stage }}
       deploy_dir: ${{ steps.meta.outputs.deploy_dir }}
+      images: ${{ steps.matrix.outputs.images }}
     steps:
       - name: Resolve stage
         id: meta
@@ -63,35 +64,26 @@ jobs:
           echo "deploy_dir=$DEPLOY_DIR" >> "$GITHUB_OUTPUT"
           echo "Deploy stage=$STAGE dir=~/$DEPLOY_DIR sha=$IMAGE_SHA"
 
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ env.IMAGE_SHA }}
+
+      - name: Load image matrix
+        id: matrix
+        run: |
+          echo "images=$(jq -c . .github/docker-images.json)" >> "$GITHUB_OUTPUT"
+
   build-push:
     runs-on: ubuntu-latest
     needs: gate
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: backend-api
-            file: docker/backend.Dockerfile
-            target: main
-            image: markjnt/palliroute-backend-api
-            cache: docker.io/markjnt/palliroute-backend-api:buildcache
-          - name: backend-scheduler
-            file: docker/backend.Dockerfile
-            target: scheduler-image
-            image: markjnt/palliroute-backend-scheduler
-            cache: docker.io/markjnt/palliroute-backend-scheduler:buildcache
-          - name: frontend-web
-            file: docker/frontend_web.Dockerfile
-            target: ""
-            image: markjnt/palliroute-frontend-web
-            cache: docker.io/markjnt/palliroute-frontend-web:buildcache
-          - name: frontend-pwa
-            file: docker/frontend_pwa.Dockerfile
-            target: ""
-            image: markjnt/palliroute-frontend-pwa
-            cache: docker.io/markjnt/palliroute-frontend-pwa:buildcache
+        include: ${{ fromJson(needs.gate.outputs.images) }}
     env:
       STAGE: ${{ needs.gate.outputs.stage }}
+      IMAGE: markjnt/palliroute-${{ matrix.name }}
+      CACHE: docker.io/markjnt/palliroute-${{ matrix.name }}:buildcache
     steps:
       - uses: actions/checkout@v7
         with:
@@ -115,10 +107,10 @@ jobs:
           push: false
           load: true
           tags: |
-            ${{ matrix.image }}:${{ env.IMAGE_SHA }}
-            ${{ matrix.image }}:${{ env.STAGE }}
-          cache-from: type=registry,ref=${{ matrix.cache }}
-          cache-to: type=registry,ref=${{ matrix.cache }},mode=max
+            ${{ env.IMAGE }}:${{ env.IMAGE_SHA }}
+            ${{ env.IMAGE }}:${{ env.STAGE }}
+          cache-from: type=registry,ref=${{ env.CACHE }}
+          cache-to: type=registry,ref=${{ env.CACHE }},mode=max
           provenance: false
           sbom: false
 
@@ -131,20 +123,20 @@ jobs:
           push: false
           load: true
           tags: |
-            ${{ matrix.image }}:${{ env.IMAGE_SHA }}
-            ${{ matrix.image }}:${{ env.STAGE }}
-          cache-from: type=registry,ref=${{ matrix.cache }}
-          cache-to: type=registry,ref=${{ matrix.cache }},mode=max
+            ${{ env.IMAGE }}:${{ env.IMAGE_SHA }}
+            ${{ env.IMAGE }}:${{ env.STAGE }}
+          cache-from: type=registry,ref=${{ env.CACHE }}
+          cache-to: type=registry,ref=${{ env.CACHE }},mode=max
           provenance: false
           sbom: false
 
       - name: Push image
         run: |
-          docker push "${{ matrix.image }}:${{ env.IMAGE_SHA }}"
-          docker push "${{ matrix.image }}:${{ env.STAGE }}"
+          docker push "${{ env.IMAGE }}:${{ env.IMAGE_SHA }}"
+          docker push "${{ env.IMAGE }}:${{ env.STAGE }}"
           if [ "${{ env.STAGE }}" = "prod" ]; then
-            docker tag "${{ matrix.image }}:${{ env.STAGE }}" "${{ matrix.image }}:latest"
-            docker push "${{ matrix.image }}:latest"
+            docker tag "${{ env.IMAGE }}:${{ env.STAGE }}" "${{ env.IMAGE }}:latest"
+            docker push "${{ env.IMAGE }}:latest"
           fi
 
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
               - 'docker/**'
               - 'docker-compose.yml'
               - '.dockerignore'
+              - '.github/docker-images.json'
             github:
               - '.github/**'
 
@@ -93,7 +94,7 @@ jobs:
       - name: Dependency audit
         run: npm audit --audit-level=high
 
-  docker-lint:
+  docker-matrix:
     runs-on: ubuntu-latest
     needs: changes
     if: |
@@ -101,27 +102,19 @@ jobs:
       needs.changes.outputs.backend == 'true' ||
       needs.changes.outputs.frontend == 'true' ||
       needs.changes.outputs.github == 'true'
+    outputs:
+      images: ${{ steps.set.outputs.images }}
+      dockerfiles: ${{ steps.set.outputs.dockerfiles }}
     steps:
       - uses: actions/checkout@v7
-      - name: Lint backend Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
-        with:
-          dockerfile: docker/backend.Dockerfile
-          failure-threshold: error
-      - name: Lint frontend web Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
-        with:
-          dockerfile: docker/frontend_web.Dockerfile
-          failure-threshold: error
-      - name: Lint frontend PWA Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
-        with:
-          dockerfile: docker/frontend_pwa.Dockerfile
-          failure-threshold: error
+      - id: set
+        run: |
+          echo "images=$(jq -c . .github/docker-images.json)" >> "$GITHUB_OUTPUT"
+          echo "dockerfiles=$(jq -c '[.[].file] | unique' .github/docker-images.json)" >> "$GITHUB_OUTPUT"
 
-  docker-ci:
+  docker-lint:
     runs-on: ubuntu-latest
-    needs: [changes, docker-lint]
+    needs: [changes, docker-matrix]
     if: |
       needs.changes.outputs.docker == 'true' ||
       needs.changes.outputs.backend == 'true' ||
@@ -130,23 +123,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: backend-api
-            file: docker/backend.Dockerfile
-            target: main
-            tag: palliroute-backend-api:ci
-          - name: backend-scheduler
-            file: docker/backend.Dockerfile
-            target: scheduler-image
-            tag: palliroute-backend-scheduler:ci
-          - name: frontend-web
-            file: docker/frontend_web.Dockerfile
-            target: ""
-            tag: palliroute-frontend-web:ci
-          - name: frontend-pwa
-            file: docker/frontend_pwa.Dockerfile
-            target: ""
-            tag: palliroute-frontend-pwa:ci
+        dockerfile: ${{ fromJson(needs.docker-matrix.outputs.dockerfiles) }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.3.0
+        with:
+          dockerfile: ${{ matrix.dockerfile }}
+          failure-threshold: error
+
+  docker-ci:
+    runs-on: ubuntu-latest
+    needs: [changes, docker-matrix, docker-lint]
+    if: |
+      needs.changes.outputs.docker == 'true' ||
+      needs.changes.outputs.backend == 'true' ||
+      needs.changes.outputs.frontend == 'true' ||
+      needs.changes.outputs.github == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.docker-matrix.outputs.images) }}
+    env:
+      IMAGE_TAG: palliroute-${{ matrix.name }}:ci
     steps:
       - uses: actions/checkout@v7
       - uses: docker/setup-buildx-action@v4
@@ -160,7 +159,7 @@ jobs:
           target: ${{ matrix.target }}
           push: false
           load: true
-          tags: ${{ matrix.tag }}
+          tags: ${{ env.IMAGE_TAG }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
           provenance: false
@@ -174,7 +173,7 @@ jobs:
           file: ${{ matrix.file }}
           push: false
           load: true
-          tags: ${{ matrix.tag }}
+          tags: ${{ env.IMAGE_TAG }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
           provenance: false
@@ -186,7 +185,7 @@ jobs:
         with:
           version: v0.71.2
           scan-type: image
-          image-ref: ${{ matrix.tag }}
+          image-ref: ${{ env.IMAGE_TAG }}
           format: json
           output: trivy-results.json
           ignore-unfixed: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ concurrency:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   changes:
@@ -92,7 +93,7 @@ jobs:
       - name: Dependency audit
         run: npm audit --audit-level=high
 
-  docker-ci:
+  docker-lint:
     runs-on: ubuntu-latest
     needs: changes
     if: |
@@ -102,7 +103,7 @@ jobs:
       needs.changes.outputs.github == 'true'
     steps:
       - uses: actions/checkout@v7
-      - name: Lint Dockerfiles
+      - name: Lint backend Dockerfile
         uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: docker/backend.Dockerfile
@@ -117,57 +118,105 @@ jobs:
         with:
           dockerfile: docker/frontend_pwa.Dockerfile
           failure-threshold: error
+
+  docker-ci:
+    runs-on: ubuntu-latest
+    needs: [changes, docker-lint]
+    if: |
+      needs.changes.outputs.docker == 'true' ||
+      needs.changes.outputs.backend == 'true' ||
+      needs.changes.outputs.frontend == 'true' ||
+      needs.changes.outputs.github == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: backend-api
+            file: docker/backend.Dockerfile
+            target: main
+            tag: palliroute-backend-api:ci
+          - name: backend-scheduler
+            file: docker/backend.Dockerfile
+            target: scheduler-image
+            tag: palliroute-backend-scheduler:ci
+          - name: frontend-web
+            file: docker/frontend_web.Dockerfile
+            target: ""
+            tag: palliroute-frontend-web:ci
+          - name: frontend-pwa
+            file: docker/frontend_pwa.Dockerfile
+            target: ""
+            tag: palliroute-frontend-pwa:ci
+    steps:
+      - uses: actions/checkout@v7
       - uses: docker/setup-buildx-action@v4
-      - name: Verify backend API image
+
+      - name: Build image
+        if: matrix.target != ''
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: docker/backend.Dockerfile
-          target: main
+          file: ${{ matrix.file }}
+          target: ${{ matrix.target }}
           push: false
           load: true
-          tags: palliroute-backend-api:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: ${{ matrix.tag }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
           provenance: false
           sbom: false
-      - name: Verify backend scheduler image
+
+      - name: Build image (default target)
+        if: matrix.target == ''
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: docker/backend.Dockerfile
-          target: scheduler-image
+          file: ${{ matrix.file }}
           push: false
           load: true
-          tags: palliroute-backend-scheduler:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: ${{ matrix.tag }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
           provenance: false
           sbom: false
-      - name: Verify frontend web image
-        uses: docker/build-push-action@v7
+
+      # ignore-unfixed: true — CVEs without an available patch are excluded from the gate.
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
-          context: .
-          file: docker/frontend_web.Dockerfile
-          push: false
-          load: true
-          tags: palliroute-frontend-web:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: false
-          sbom: false
-      - name: Verify frontend PWA image
-        uses: docker/build-push-action@v7
+          version: v0.71.2
+          scan-type: image
+          image-ref: ${{ matrix.tag }}
+          format: json
+          output: trivy-results.json
+          ignore-unfixed: true
+          scanners: vuln
+          list-all-pkgs: true
+          exit-code: 0
+
+      - name: Generate reports and gate on findings
+        run: |
+          trivy convert --format sarif --severity CRITICAL,HIGH \
+            --output trivy-results.sarif trivy-results.json
+          trivy convert --format spdx-json \
+            --output "sbom-${{ matrix.name }}.spdx.json" trivy-results.json
+          trivy convert --format table --severity CRITICAL,HIGH --scanners vuln \
+            --exit-code 1 trivy-results.json
+
+      - name: Upload Trivy SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        if: ${{ !cancelled() && hashFiles('trivy-results.sarif') != '' }}
         with:
-          context: .
-          file: docker/frontend_pwa.Dockerfile
-          push: false
-          load: true
-          tags: palliroute-frontend-pwa:ci
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: false
-          sbom: false
+          sarif_file: trivy-results.sarif
+          category: trivy-${{ matrix.name }}
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: sbom-${{ matrix.name }}
+          path: sbom-${{ matrix.name }}.spdx.json
+          retention-days: 90
 
   security-ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,3 +244,44 @@ jobs:
         uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Always runs so branch protection can require this single check.
+  # Path-filtered jobs may be "skipped"; that counts as OK here.
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - changes
+      - backend-ci
+      - frontend-ci
+      - docker-matrix
+      - docker-lint
+      - docker-ci
+      - security-ci
+    steps:
+      - name: Verify CI jobs
+        run: |
+          results=(
+            "changes:${{ needs.changes.result }}"
+            "backend-ci:${{ needs.backend-ci.result }}"
+            "frontend-ci:${{ needs.frontend-ci.result }}"
+            "docker-matrix:${{ needs.docker-matrix.result }}"
+            "docker-lint:${{ needs.docker-lint.result }}"
+            "docker-ci:${{ needs.docker-ci.result }}"
+            "security-ci:${{ needs.security-ci.result }}"
+          )
+          failed=0
+          for entry in "${results[@]}"; do
+            name="${entry%%:*}"
+            result="${entry##*:}"
+            echo "$name → $result"
+            case "$result" in
+              success|skipped) ;;
+              *)
+                echo "::error::$name finished with $result"
+                failed=1
+                ;;
+            esac
+          done
+          exit "$failed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,11 +194,28 @@ jobs:
           exit-code: 0
 
       - name: Generate reports and gate on findings
+        if: always() && hashFiles('trivy-results.json') != ''
         run: |
           trivy convert --format sarif --severity CRITICAL,HIGH \
             --output trivy-results.sarif trivy-results.json
           trivy convert --format spdx-json \
             --output "sbom-${{ matrix.name }}.spdx.json" trivy-results.json
+          trivy convert --format table --severity CRITICAL,HIGH --scanners vuln \
+            --output trivy-results.txt trivy-results.json
+
+          {
+            echo "### Trivy: \`${{ matrix.name }}\`"
+            echo ""
+            if [[ -s trivy-results.txt ]]; then
+              echo '```'
+              cat trivy-results.txt
+              echo '```'
+            else
+              echo "No CRITICAL/HIGH findings."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Fail the job on CRITICAL/HIGH (same gate as before)
           trivy convert --format table --severity CRITICAL,HIGH --scanners vuln \
             --exit-code 1 trivy-results.json
 
@@ -211,7 +228,7 @@ jobs:
 
       - name: Upload SBOM
         uses: actions/upload-artifact@v7
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && hashFiles('sbom-${{ matrix.name }}.spdx.json') != '' }}
         with:
           name: sbom-${{ matrix.name }}
           path: sbom-${{ matrix.name }}.spdx.json

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
   push:
-    branches: [main]
+    branches: [main, dev]
   schedule:
     - cron: '0 6 * * 1'
 

--- a/backend/requirements-scheduler.txt
+++ b/backend/requirements-scheduler.txt
@@ -2,6 +2,6 @@ requests==2.34.2
 apscheduler==3.10.4
 dotenv==0.9.9
 # Base-image pins for Trivy HIGH findings
-setuptools==78.1.1
+setuptools==83.0.0
 jaraco.context==6.1.0
 wheel==0.46.2

--- a/backend/requirements-scheduler.txt
+++ b/backend/requirements-scheduler.txt
@@ -1,5 +1,7 @@
 requests==2.34.2
 apscheduler==3.10.4
 dotenv==0.9.9
-# Base-image pin for Trivy HIGH (CVE-2025-47273)
+# Base-image pins for Trivy HIGH findings
 setuptools==78.1.1
+jaraco.context==6.1.0
+wheel==0.46.2

--- a/backend/requirements-scheduler.txt
+++ b/backend/requirements-scheduler.txt
@@ -1,7 +1,3 @@
 requests==2.34.2
 apscheduler==3.10.4
 dotenv==0.9.9
-# Base-image pins for Trivy HIGH findings
-setuptools==83.0.0
-jaraco.context==6.1.0
-wheel==0.46.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,13 +8,7 @@ pandas==3.0.5
 openpyxl==3.1.5
 googlemaps==4.10.0
 gunicorn==23.0.0
-apscheduler==3.10.4
 requests==2.34.2
 weasyprint==69.0
 jinja2==3.1.6
 ortools==9.15.6755
-# Transitive / base-image pins for Trivy HIGH findings
-msgpack==1.2.1
-setuptools==83.0.0
-jaraco.context==6.1.0
-wheel==0.46.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,6 +15,6 @@ jinja2==3.1.6
 ortools==9.15.6755
 # Transitive / base-image pins for Trivy HIGH findings
 msgpack==1.2.1
-setuptools==78.1.1
+setuptools==83.0.0
 jaraco.context==6.1.0
 wheel==0.46.2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,3 +16,5 @@ ortools==9.15.6755
 # Transitive / base-image pins for Trivy HIGH findings
 msgpack==1.2.1
 setuptools==78.1.1
+jaraco.context==6.1.0
+wheel==0.46.2

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -27,10 +27,18 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 
 WORKDIR /backend
 
-# WeasyPrint via apt (version pinned by Debian bookworm package index)
+# Native libs for pip weasyprint (do not apt-install the weasyprint package —
+# it pulls outdated system Python pkgs that Trivy flags alongside pip installs).
 # hadolint ignore=DL3008
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends weasyprint \
+    && apt-get install -y --no-install-recommends \
+        libcairo2 \
+        libpango-1.0-0 \
+        libpangocairo-1.0-0 \
+        libgdk-pixbuf-2.0-0 \
+        libffi8 \
+        shared-mime-info \
+        fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better layer caching

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -11,7 +11,8 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 WORKDIR /scheduler
 
 COPY backend/requirements-scheduler.txt .
-RUN pip install --no-cache-dir -r requirements-scheduler.txt
+RUN pip install --no-cache-dir -r requirements-scheduler.txt \
+    && rm -rf /usr/local/lib/python*/ensurepip /usr/local/lib/python*/test/wheeldata
 
 # Copy only scheduler script and config
 COPY backend/run_scheduler.py .
@@ -47,7 +48,10 @@ COPY backend/requirements.txt .
 # hadolint ignore=DL3042
 RUN --mount=type=cache,target=/root/.cache/pip \
     python -m pip install --no-cache-dir -U pip && \
-    pip install --no-cache-dir --prefer-binary -r requirements.txt
+    pip install --no-cache-dir --prefer-binary -r requirements.txt && \
+    # Official python images ship outdated setuptools wheels under ensurepip/test;
+    # Trivy flags those even when site-packages already has patched versions.
+    rm -rf /usr/local/lib/python*/ensurepip /usr/local/lib/python*/test/wheeldata
 
 # Copy backend code
 COPY backend/ .

--- a/docker/backend.Dockerfile
+++ b/docker/backend.Dockerfile
@@ -11,8 +11,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 WORKDIR /scheduler
 
 COPY backend/requirements-scheduler.txt .
-RUN pip install --no-cache-dir -r requirements-scheduler.txt \
-    && rm -rf /usr/local/lib/python*/ensurepip /usr/local/lib/python*/test/wheeldata
+RUN pip install --no-cache-dir -r requirements-scheduler.txt
 
 # Copy only scheduler script and config
 COPY backend/run_scheduler.py .
@@ -28,8 +27,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 
 WORKDIR /backend
 
-# Native libs for pip weasyprint (do not apt-install the weasyprint package —
-# it pulls outdated system Python pkgs that Trivy flags alongside pip installs).
+# Native libs for pip weasyprint
 # hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -44,14 +42,7 @@ RUN apt-get update \
 
 # Copy requirements first for better layer caching
 COPY backend/requirements.txt .
-
-# hadolint ignore=DL3042
-RUN --mount=type=cache,target=/root/.cache/pip \
-    python -m pip install --no-cache-dir -U pip && \
-    pip install --no-cache-dir --prefer-binary -r requirements.txt && \
-    # Official python images ship outdated setuptools wheels under ensurepip/test;
-    # Trivy flags those even when site-packages already has patched versions.
-    rm -rf /usr/local/lib/python*/ensurepip /usr/local/lib/python*/test/wheeldata
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy backend code
 COPY backend/ .
@@ -73,4 +64,4 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 # Create scheduler image
 FROM scheduler AS scheduler-image
-CMD ["python", "run_scheduler.py"] 
+CMD ["python", "run_scheduler.py"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2285,9 +2285,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2383,9 +2383,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4346,9 +4346,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5252,9 +5252,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5397,9 +5397,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -5462,9 +5462,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6565,9 +6565,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -6903,9 +6903,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -7205,9 +7205,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -7225,7 +7225,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7420,9 +7420,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -7442,12 +7442,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/packages/models/src/models.ts
+++ b/frontend/packages/models/src/models.ts
@@ -33,7 +33,7 @@ export interface Employee {
   updated_at?: string;
 }
 
-export interface EmployeeFormData extends Omit<Employee, 'id' | 'created_at' | 'updated_at'> {}
+export type EmployeeFormData = Omit<Employee, 'id' | 'created_at' | 'updated_at'>;
 
 export interface EmployeeImportResponse {
   message: string;

--- a/frontend/pwa/src/App.tsx
+++ b/frontend/pwa/src/App.tsx
@@ -62,10 +62,14 @@ const theme = createTheme({
   },
 });
 
+interface NavigatorWithStandalone extends Navigator {
+  standalone?: boolean;
+}
+
 const App: React.FC = () => {
   const isInstalled =
     window.matchMedia('(display-mode: standalone)').matches ||
-    (window.navigator as any).standalone === true ||
+    (window.navigator as NavigatorWithStandalone).standalone === true ||
     document.referrer.includes('android-app://');
 
   // Choose backend based on device capabilities

--- a/frontend/pwa/src/components/layout/MainBottomSheet.tsx
+++ b/frontend/pwa/src/components/layout/MainBottomSheet.tsx
@@ -1,5 +1,5 @@
 import { Sheet, SheetRef } from 'react-modal-sheet';
-import { useState, useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
+import { useRef, useEffect, forwardRef, useImperativeHandle } from 'react';
 import { RouteInfo } from '../route/RouteInfo';
 import { RouteList } from '../route/RouteList';
 import { useAdditionalRoutesStore } from '../../stores/useAdditionalRoutesStore';
@@ -12,14 +12,11 @@ interface MainBottomSheetProps {
   onClose: () => void;
 }
 
-export interface MainBottomSheetRef {
-  // No methods needed for simple open/close behavior
-}
+export type MainBottomSheetRef = Record<string, never>;
 
 export const MainBottomSheet = forwardRef<MainBottomSheetRef, MainBottomSheetProps>(
   ({ isOpen, onClose }, ref) => {
     const sheetRef = useRef<SheetRef>(null);
-    const [currentSnap, setCurrentSnap] = useState(1);
     const { shouldRender: shouldRenderSheet, onCloseEnd } = useDeferredSheetMount(isOpen);
     const { resetForNewUser } = useAdditionalRoutesStore();
     const { selectedUserId, selectedTourArea } = useUserStore();
@@ -31,10 +28,6 @@ export const MainBottomSheet = forwardRef<MainBottomSheetRef, MainBottomSheetPro
     useEffect(() => {
       resetForNewUser();
     }, [selectedUserId, selectedTourArea, resetForNewUser]);
-
-    const handleSnapChange = (snapIndex: number) => {
-      setCurrentSnap(snapIndex);
-    };
 
     // No imperative methods needed for simple open/close behavior
     useImperativeHandle(ref, () => ({}), []);
@@ -52,7 +45,6 @@ export const MainBottomSheet = forwardRef<MainBottomSheetRef, MainBottomSheetPro
           onCloseEnd={onCloseEnd}
           initialSnap={0}
           snapPoints={snapPoints}
-          onSnap={handleSnapChange}
           disableDrag={isDragging}
         >
           <Sheet.Container>

--- a/frontend/pwa/src/components/layout/MainLayout.tsx
+++ b/frontend/pwa/src/components/layout/MainLayout.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { Box, SwipeableDrawer, Button, Menu, MenuItem, Typography } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
+import { Box } from '@mui/material';
 import { MapView } from './MainViewMap';
 import { useUserStore } from '../../stores/useUserStore';
 import { useWeekdayStore } from '../../stores/useWeekdayStore';
@@ -9,12 +8,17 @@ import UserSearchDrawer from '../user/UserSelectSheet';
 import { TopOverviewBar } from './TopOverviewBar';
 import StaleRefreshDialog from '../refresh/StaleRefreshDialog';
 
+declare global {
+  interface Window {
+    __closeWeekdaySelector?: () => void;
+  }
+}
+
 const WEEKDAY_STORAGE_KEY = 'pwa-weekday-storage';
 
 const MainLayout: React.FC = () => {
   const { selectedUserId, selectedTourArea } = useUserStore();
   const { resetToCurrentDay, resetToCurrentAreaDay } = useWeekdayStore();
-  const navigate = useNavigate();
   const [isUserDrawerOpen, setIsUserDrawerOpen] = useState(false);
   const [isSheetOpen, setIsSheetOpen] = useState(false);
 
@@ -89,9 +93,7 @@ const MainLayout: React.FC = () => {
     setIsSheetOpen(false);
     setIsUserDrawerOpen(false); // Also close user select sheet when map/outside is clicked
     // Also close weekday selector when map is clicked
-    if ((window as any).__closeWeekdaySelector) {
-      (window as any).__closeWeekdaySelector();
-    }
+    window.__closeWeekdaySelector?.();
   };
 
   return (

--- a/frontend/pwa/src/components/layout/TopOverviewBar.tsx
+++ b/frontend/pwa/src/components/layout/TopOverviewBar.tsx
@@ -41,9 +41,9 @@ export const TopOverviewBar: React.FC<TopOverviewBarProps> = ({
         setIsWeekdayMenuOpen(false);
       };
       // Store close handler so it can be called from MainLayout
-      (window as any).__closeWeekdaySelector = closeHandler;
+      window.__closeWeekdaySelector = closeHandler;
       return () => {
-        delete (window as any).__closeWeekdaySelector;
+        delete window.__closeWeekdaySelector;
       };
     }
   }, [onCloseWeekdaySelector]);


### PR DESCRIPTION
## Summary
- Promote staging/dev CI/CD: Trivy in CI, shared docker-images matrix, CodeQL on `dev`, CD run-name with stage/branch
- Add always-on `CI` gate so branch protection works with path-filtered jobs
- Harden Docker/backend install (direct deps only, WeasyPrint/pip cleanup) and bump setup-node/setup-python for Node 24
- Clear PWA ESLint noise (unused imports/`any`, empty interface)

## Test plan
- [ ] Confirm required check is only `CI` (not individual path-filtered jobs)
- [ ] Merge with a docs-only change → path-filtered jobs skip, `CI` still green
- [ ] Merge with frontend/docker change → affected jobs run and gate fails on real errors
- [ ] Spot-check CD `run-name` and staging deploy path after merge to `main`
