### PR TITLE
Serve PWA on Traefik HTTP without catch-all dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,7 +149,6 @@ services:
       - "traefik.docker.network=traefik-public"
       - "traefik.http.routers.pwa-${STAGE:-prod}.rule=Host(`${PWA_DOMAIN}`)"
       - "traefik.http.routers.pwa-${STAGE:-prod}.entrypoints=web"
-      - "traefik.http.routers.pwa-${STAGE:-prod}.priority=100"
       - "traefik.http.services.pwa-${STAGE:-prod}.loadbalancer.server.port=3001"
       - "traefik.http.services.pwa-${STAGE:-prod}.loadbalancer.server.scheme=http"
 

--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -30,14 +30,6 @@ services:
     restart: unless-stopped
     labels:
       - "traefik.enable=true"
-      # HTTP→HTTPS for everything on :80 except routers with higher priority (PWA, Kompass).
-      - "traefik.http.middlewares.redirect-https.redirectscheme.scheme=https"
-      - "traefik.http.middlewares.redirect-https.redirectscheme.permanent=true"
-      - "traefik.http.routers.http-catchall.rule=PathPrefix(`/`)"
-      - "traefik.http.routers.http-catchall.entrypoints=web"
-      - "traefik.http.routers.http-catchall.middlewares=redirect-https"
-      - "traefik.http.routers.http-catchall.priority=1"
-      - "traefik.http.routers.http-catchall.service=api@internal"
 
 networks:
   traefik-public:


### PR DESCRIPTION
## Summary
- Catch-all auf Port 80 entfernt (der hat das Traefik-Dashboard ausgeliefert, sobald Sophos `X-Forwarded-Proto: https` setzt).
- Überflüssige PWA-`priority` entfernt. PWA bleibt auf HTTP `:80` hinter Sophos; Web intern weiter auf `:443` / Let’s Encrypt.

Ersetzt #53: der zeigte durch den Squash von #52 die komplette `dev`-Historie, obwohl nur diese zwei Dateien fehlen.

## Test plan
- [ ] Intern: `https://web.…` über Traefik :443
- [ ] PWA über Sophos (Pass host header) ohne 404/Dashboard
- [ ] Nach Merge `main` zurück nach `dev` mergen, damit die Branches gleich bleiben