### PR TITLE
Fix employee import failing on leftover capacities and assignments.

### DIFF
--- a/backend/app/api_routes/employees.py
+++ b/backend/app/api_routes/employees.py
@@ -8,6 +8,7 @@ from app.models.appointment import Appointment
 from app.models.employee import Employee
 from app.models.employee_planning import EmployeePlanning
 from app.models.route import Route
+from app.models.scheduling import Assignment, EmployeeAutoPlanningPreference, EmployeeCapacity
 from app.services.excel_import_service import ExcelImportService
 
 employees_bp = Blueprint("employees", __name__)
@@ -155,9 +156,16 @@ def delete_employee(id):
 
         # Delete related appointments
         Appointment.query.filter_by(employee_id=id).delete()
+        Appointment.query.filter_by(origin_employee_id=id).update({"origin_employee_id": None})
+        Appointment.query.filter_by(tour_employee_id=id).update({"tour_employee_id": None})
 
         # Delete related employee planning
+        EmployeePlanning.query.filter_by(replacement_id=id).update({"replacement_id": None})
         EmployeePlanning.query.filter_by(employee_id=id).delete()
+
+        EmployeeCapacity.query.filter_by(employee_id=id).delete()
+        Assignment.query.filter_by(employee_id=id).delete()
+        EmployeeAutoPlanningPreference.query.filter_by(employee_id=id).delete()
 
         # Now delete the employee
         db.session.delete(employee)

--- a/backend/app/services/excel_import_service.py
+++ b/backend/app/services/excel_import_service.py
@@ -14,7 +14,13 @@ from ..models.employee_planning import EmployeePlanning
 from ..models.patient import Patient
 from ..models.pflegeheim import Pflegeheim
 from ..models.route import Route
-from ..models.scheduling import Assignment, EmployeeCapacity, ShiftDefinition, ShiftInstance
+from ..models.scheduling import (
+    Assignment,
+    EmployeeAutoPlanningPreference,
+    EmployeeCapacity,
+    ShiftDefinition,
+    ShiftInstance,
+)
 from ..models.system_info import SystemInfo
 from .holiday_service import (
     date_for_iso_week_and_weekday,
@@ -218,10 +224,25 @@ class ExcelImportService:
     def cleanup_employee_references(employee_id):
         """
         Clean up references to an employee before deletion:
+        - Delete capacities, shift assignments, and auto-planning preferences
         - Set employee_id to NULL in routes
         - Set employee_id, origin_employee_id, and tour_employee_id to NULL in appointments
         """
         try:
+            capacities_deleted = EmployeeCapacity.query.filter_by(employee_id=employee_id).delete()
+            if capacities_deleted > 0:
+                print(f"  Deleted {capacities_deleted} capacity entries")
+
+            assignments_deleted = Assignment.query.filter_by(employee_id=employee_id).delete()
+            if assignments_deleted > 0:
+                print(f"  Deleted {assignments_deleted} shift assignments")
+
+            preferences_deleted = EmployeeAutoPlanningPreference.query.filter_by(
+                employee_id=employee_id
+            ).delete()
+            if preferences_deleted > 0:
+                print(f"  Deleted {preferences_deleted} auto-planning preferences")
+
             # Update routes: set employee_id to NULL
             routes_updated = Route.query.filter_by(employee_id=employee_id).update(
                 {"employee_id": None}


### PR DESCRIPTION
Employees missing from Excel are deleted; related capacity, assignment, and preference rows are now removed first so foreign-key constraints are not violated.